### PR TITLE
Bug/vea 39 email template not being loaded from jar file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.danieldigiovanni</groupId>
     <artifactId>email</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <name>email</name>
     <description>REST API sending verification emails</description>
     <properties>

--- a/src/main/java/com/danieldigiovanni/email/config/EmailTemplateConfig.java
+++ b/src/main/java/com/danieldigiovanni/email/config/EmailTemplateConfig.java
@@ -4,21 +4,23 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 
+import java.io.BufferedReader;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
 
 @Configuration
 public class EmailTemplateConfig {
 
     @Bean("emailHtmlTemplate")
     public String emailHtmlTemplate() throws IOException {
-        Path path = new ClassPathResource("emailTemplate.html")
-            .getFile()
-            .toPath();
-
-        return Files.readString(path, StandardCharsets.UTF_8);
+        InputStream inputStream =
+            new ClassPathResource("emailTemplate.html").getInputStream();
+        BufferedReader reader =
+            new BufferedReader(new InputStreamReader(inputStream));
+        return reader.lines()
+            .collect(Collectors.joining(System.lineSeparator()));
     }
 
 }


### PR DESCRIPTION
Fixed bug by loading email template as an input stream instead of a file.