### PR TITLE
Bug/VEA-49 emailer profile for tests

### DIFF
--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,3 +1,5 @@
+spring.profiles.active=no-op
+
 spring.datasource.url=jdbc:h2:mem:test-db
 spring.datasource.driverClassName=org.h2.Driver
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
@@ -6,8 +8,6 @@ token-duration-millis=7200000
 token-secret-key=SECRETSECRETSECRETSECRETSECRETSECRETSECRETSECRETSECRET
 
 whitelisted-routes=/register,/login
-
-emailer-method=no-op
 
 emailer.api.from-address=noreply@myemail.com
 emailer.api.send-email-url=https://mail.api/send-email


### PR DESCRIPTION
The tests were failing because the emailer profile was not defined for tests. Added the no-op emailer active profile for tests so that tests will use the no-op emailer.